### PR TITLE
Make it work on Ubuntu 16.04

### DIFF
--- a/bin/git-submodule-rewrite
+++ b/bin/git-submodule-rewrite
@@ -51,8 +51,11 @@ EOF
 }
 
 function git_version_lte() {
+  OP_VERSION=$(printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' '\n' | head -n 4))
   GIT_VERSION=$(git version)
-  [ "$1" = $(echo -e "${GIT_VERSION#git version}\n$1" | sort -V | head -n1) ]
+  GIT_VERSION=$(printf "%03d%03d%03d%03d" $(echo "${GIT_VERSION#git version}" | tr '.' '\n' | head -n 4))
+  echo -e "${GIT_VERSION}\n${OP_VERSION}" | sort | head -n1
+  [ ${OP_VERSION} -le ${GIT_VERSION} ]
 }
 
 function main() {

--- a/bin/git-submodule-rewrite
+++ b/bin/git-submodule-rewrite
@@ -50,6 +50,11 @@ EOF
   request_confirmation "Do you want to proceed?"
 }
 
+function git_version_lte() {
+  GIT_VERSION=$(git version)
+  [ "$1" = $(echo -e "${GIT_VERSION#git version}\n$1" | sort -V | head -n1) ]
+}
+
 function main() {
 
   warn
@@ -78,7 +83,17 @@ function main() {
   # Merge in rewritten submodule history
   git remote add "${sub}" "${tmpdir}"
   git fetch "${sub}"
-  git merge -s ours --no-commit --allow-unrelated-histories "${sub}/master"
+
+  if git_version_lte 2.8.4
+  then
+    # Previous to git 2.9.0 the parameter would yield an error
+    ALLOW_UNRELATED_HISTORIES=""
+  else
+    # From git 2.9.0 this parameter is required
+    ALLOW_UNRELATED_HISTORIES="--allow-unrelated-histories"
+  fi
+
+  git merge -s ours --no-commit ${ALLOW_UNRELATED_HISTORIES} "${sub}/master"
   rm -rf tmpdir
 
   # Add submodule content

--- a/bin/git-submodule-rewrite
+++ b/bin/git-submodule-rewrite
@@ -72,7 +72,7 @@ function main() {
   rm -rf ".git/modules/${sub}"
 
   # Rewrite submodule history
-  local tmpdir="$(mktemp -d -t submodule-rewrite)"
+  local tmpdir="$(mktemp -d -t submodule-rewrite-XXXXXX)"
   git clone "${url}" "${tmpdir}"
   pushd "${tmpdir}"
   local tab="$(printf '\t')"


### PR DESCRIPTION
Requires two fixes:

* mktemp requires "XXX"
* Ubuntu git is at version 2.7.4, which does not yet have `--allow-unrelated-histories`