### PR TITLE
filter fx

### DIFF
--- a/bin/git-submodule-rewrite
+++ b/bin/git-submodule-rewrite
@@ -81,7 +81,7 @@ function main() {
   git clone "${url}" "${tmpdir}"
   pushd "${tmpdir}"
   local tab="$(printf '\t')"
-  local filter="git ls-files -s | sed \"s/${tab}/${tab}${path}\//\" | GIT_INDEX_FILE=\${GIT_INDEX_FILE}.new git update-index --index-info && mv \${GIT_INDEX_FILE}.new \${GIT_INDEX_FILE}"
+  local filter="git ls-files -s | sed \"s/${tab}/${tab}${path}\//\" | GIT_INDEX_FILE=\${GIT_INDEX_FILE}.new git update-index --index-info && mv \${GIT_INDEX_FILE}.new \${GIT_INDEX_FILE} || true"
   git filter-branch --index-filter "${filter}" HEAD
   popd
 


### PR DESCRIPTION
fixes situations when commit is empty.
For example:

Rewrite e97e736be5181ac02c3c8aea6ded8ebb923d002f (1/62) (0 seconds passed, remaining 0 predicted)    mv: /var/folders/9j/xp0yqk9j53jblz2js33ghjcw0000gn/T/submodule-rewrite-XXXXXX.CxVsFEDE/.git-rewrite/t/../index.new: No such file or directory