### PR TITLE
Fix broken checking of Git version

### DIFF
--- a/bin/git-submodule-rewrite
+++ b/bin/git-submodule-rewrite
@@ -55,7 +55,7 @@ function git_version_lte() {
   GIT_VERSION=$(git version)
   GIT_VERSION=$(printf "%03d%03d%03d%03d" $(echo "${GIT_VERSION#git version}" | tr '.' '\n' | head -n 4))
   echo -e "${GIT_VERSION}\n${OP_VERSION}" | sort | head -n1
-  [ ${OP_VERSION} -le ${GIT_VERSION} ]
+  [ ${GIT_VERSION} -le ${OP_VERSION} ]
 }
 
 function main() {


### PR DESCRIPTION
The -le comparison had its operands the wrong way round here, so I wasn't getting the required `--allow-unrelated-histories` argument passed to the merge operation.