### PR TITLE
Added support for merging in submodules of submodules

### DIFF
--- a/bin/git-submodule-rewrite
+++ b/bin/git-submodule-rewrite
@@ -29,7 +29,7 @@ function warn() {
   cat << EOF
     This script will convert your "${sub}" git submodule into
     a simple subdirectory in the parent repository while retaining all
-    contents and file history.
+    contents, file history and its own submodules.
 
     The script will:
       * delete the ${sub} submodule configuration from .gitmodules and
@@ -39,6 +39,8 @@ function warn() {
         This ensures that git log will correctly follow the original file
         history.
       * merge the submodule into its parent repository and commit it.
+      * reinstate any of the submodule's own submodules as part of the parent
+        repository
 
     NOTE: This script might completely garble your repository, so PLEASE apply
     this only to a fresh clone of the repository where it does not matter if
@@ -104,8 +106,25 @@ function main() {
 
   # Add submodule content
   git clone -b "${branch}" "${url}" "${path}"
-  rm -rf "${path}/.git"
+
+  # Transfer its own submodules to the parent
+  sub_names=$(git config -f ${path}/.gitmodules --name-only --get-regexp path | sed -re "s/^submodule\.(.+)\.path$/\1/g")
+  add_submod_cmds=""
+
+  for sub_name in ${sub_names}; do
+    sub_branch=$(git config -f ${path}/.gitmodules --get "submodule.${sub_name}.branch") || true
+    [ -n "${sub_branch}" ] && sub_branch="-b ${sub_branch}"
+    sub_path=$(git config -f ${path}/.gitmodules --get "submodule.${sub_name}.path")
+    sub_url=$(git config -f ${path}/.gitmodules --get "submodule.${sub_name}.url")
+
+    # remove the sub-submodule (which should be empty) and cache the command to reinstate it
+    rmdir ${path}/${sub_path}
+    add_submod_cmds="$add_submod_cmds git submodule add ${sub_branch} --name ${sub_name} -- ${sub_url} ${path}/${sub_path} ; "
+  done
+
+  rm -rf "${path}/.git" "${path}/.gitmodules"
   git add "${path}"
+  bash -c "${add_submod_cmds}"
   git commit -m "Merge submodule contents for ${sub}/${branch}"
   git config -f .git/config --remove-section "remote.${sub}"
 

--- a/bin/git-submodule-rewrite
+++ b/bin/git-submodule-rewrite
@@ -108,23 +108,28 @@ function main() {
   git clone -b "${branch}" "${url}" "${path}"
 
   # Transfer its own submodules to the parent
-  sub_names=$(git config -f ${path}/.gitmodules --name-only --get-regexp path | sed -re "s/^submodule\.(.+)\.path$/\1/g")
   add_submod_cmds=""
+  if [ -f ${path}/.gitmodules ]; then
+    sub_names=$(git config -f ${path}/.gitmodules --name-only --get-regexp path | sed -re "s/^submodule\.(.+)\.path$/\1/g")
 
-  for sub_name in ${sub_names}; do
-    sub_branch=$(git config -f ${path}/.gitmodules --get "submodule.${sub_name}.branch") || true
-    [ -n "${sub_branch}" ] && sub_branch="-b ${sub_branch}"
-    sub_path=$(git config -f ${path}/.gitmodules --get "submodule.${sub_name}.path")
-    sub_url=$(git config -f ${path}/.gitmodules --get "submodule.${sub_name}.url")
+    for sub_name in ${sub_names}; do
+      sub_branch=$(git config -f ${path}/.gitmodules --get "submodule.${sub_name}.branch") || true
+      [ -n "${sub_branch}" ] && sub_branch="-b ${sub_branch}"
+      sub_path=$(git config -f ${path}/.gitmodules --get "submodule.${sub_name}.path")
+      sub_url=$(git config -f ${path}/.gitmodules --get "submodule.${sub_name}.url")
 
-    # remove the sub-submodule (which should be empty) and cache the command to reinstate it
-    rmdir ${path}/${sub_path}
-    add_submod_cmds="$add_submod_cmds git submodule add ${sub_branch} --name ${sub_name} -- ${sub_url} ${path}/${sub_path} ; "
-  done
+      # remove the sub-submodule (which should be empty) and cache the command to reinstate it
+      rmdir ${path}/${sub_path}
+      add_submod_cmds="$add_submod_cmds git submodule add ${sub_branch} --name ${sub_name} -- ${sub_url} ${path}/${sub_path} ; "
+    done
+  fi
 
   rm -rf "${path}/.git" "${path}/.gitmodules"
   git add "${path}"
-  bash -c "${add_submod_cmds}"
+  if [ -n "${add_submod_cmds}" ]; then
+    bash -c "${add_submod_cmds}"
+  fi
+
   git commit -m "Merge submodule contents for ${sub}/${branch}"
   git config -f .git/config --remove-section "remote.${sub}"
 


### PR DESCRIPTION
I've covered the corner cases I could think of; it'll get into difficulties if one of the nested submodules has the same name as a submodule that already exists in the parent, but I didn't want to arbitrarily rename them or overcomplicate the script, so I think that can reasonably be left for the end-user. As it stands, the `git submodule add` commands run at the end will bail out in this case.

Fixes #7 