### PR TITLE
Trim info that `git version` prints after the version number

### DIFF
--- a/bin/git-submodule-rewrite
+++ b/bin/git-submodule-rewrite
@@ -56,7 +56,7 @@ EOF
 function git_version_lte() {
   OP_VERSION=$(printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' '\n' | head -n 4))
   GIT_VERSION=$(git version)
-  GIT_VERSION=$(printf "%03d%03d%03d%03d" $(echo "${GIT_VERSION#git version}" | tr '.' '\n' | head -n 4))
+  GIT_VERSION=$(printf "%03d%03d%03d%03d" $(echo "${GIT_VERSION#git version }" | sed -E "s/([0-9.]*).*/\1/" | tr '.' '\n' | head -n 4))
   echo -e "${GIT_VERSION}\n${OP_VERSION}" | sort | head -n1
   [ ${GIT_VERSION} -le ${OP_VERSION} ]
 }


### PR DESCRIPTION
For example, on Mac OS the output of `git version` is

```bash
$ git version
git version 2.13.5 (Apple Git-94)
```

The additional `(Apple Git-94)` breaks the previous code. This addition trims
that extra material out before the remainder is parsed as a sequence of numbers.

Closes #9