### PR TITLE
Add force option to skip warning

### DIFF
--- a/bin/git-submodule-rewrite
+++ b/bin/git-submodule-rewrite
@@ -12,6 +12,7 @@ function usage(){
   echo ""
   echo "options:"
   echo "  -h, --help                Print this message"
+  echo "  -f, --force               Skip the warning message (use with caution)"
   echo "  -v, --verbose             Display verbose output"
 }
 
@@ -81,7 +82,9 @@ function absolute_url {
 
 function main() {
 
-  warn
+  if [ "${skip_warn}" != "true" ]; then
+	warn
+  fi
 
   if [ "${verbose}" == "true" ]; then
     set -x
@@ -158,6 +161,7 @@ function main() {
 set -euo pipefail
 
 declare verbose=false
+declare skip_warn=false
 while [ $# -gt 0 ]; do
     case "$1" in
         (-h|--help)
@@ -167,6 +171,9 @@ while [ $# -gt 0 ]; do
         (-v|--verbose)
             verbose=true
             ;;
+	(-f|--force)
+	    skip_warn=true
+	    ;;
         (*)
             break
             ;;


### PR DESCRIPTION
I wanted to put this in a script since I had ~20 submodules in a single folder that I was consolidating into one repo, so I added a force option.